### PR TITLE
[VT Hashing] fix bug where variable does not actually hold hash

### DIFF
--- a/Sooty.py
+++ b/Sooty.py
@@ -534,8 +534,8 @@ def hashAndFileUpload():
     with open(root.filename, 'rb') as afile:
         buf = afile.read()
         hasher.update(buf)
-    print(" MD5 Hash: " + hasher.hexdigest())
-    fileHash = hasher.hexdigest
+    fileHash = hasher.hexdigest()
+    print(" MD5 Hash: " + fileHash)
     root.destroy()
     count = 0
     # VT Hash Checker


### PR DESCRIPTION
pretty self explanatory, this must have been an oversight, hexdigest is not properly called, leading to this never succesfully submitting the hash.