### PR TITLE
Fix for Issue#42 - Add the ability to use Email Rep API Key in request 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Sooty is now proudly supported by [Tines.io](https://tines.io?utm_source=github&
    - [AbuseIPDB API Key](https://www.abuseipdb.com/api)
    - [HaveIBeenPwned API Key](https://haveibeenpwned.com/API/Key)
    - [PhishTank API Key](https://www.phishtank.com/api_info.php)
+   - [EMAILREP API KEY](https://emailrep.io/key)
  - Replace the corresponding key in the `example_config.yaml` file, and rename the file to `config.yaml`, example layout below:
  - For PhishTank support, an unique app name is also required as an additional field. Simply update the `config.yaml` file with your unique name.
  

--- a/Sooty.py
+++ b/Sooty.py
@@ -798,9 +798,15 @@ def analyzeEmail(email):
 
     try:
         url = 'https://emailrep.io/'
+        userAgent = 'Sooty'
         summary = '?summary=true'
         url = url + email + summary
-        response = requests.get(url)
+        if 'API Key' not in configvars.data['EMAILREP_API_KEY']:
+            erep_key = configvars.data['EMAILREP_API_KEY']
+            headers = {'Content-Type': 'application/json', 'Key': configvars.data['EMAILREP_API_KEY'], 'User-Agent': userAgent}
+            response = requests.get(url, headers=headers)
+        else:
+            response = requests.get(url)
         req = response.json()
         emailDomain = re.split('@', email)[1]
 
@@ -840,7 +846,6 @@ def analyzeEmail(email):
             if (req['details']['data_breach']):
                 try:
                     url = 'https://haveibeenpwned.com/api/v3/breachedaccount/%s' % email
-                    userAgent = 'Sooty'
                     headers = {'Content-Type': 'application/json', 'hibp-api-key': configvars.data['HIBP_API_KEY'], 'user-agent': userAgent}
 
                     try:


### PR DESCRIPTION
## Description ##
Request to Email-Rep API will now be able to give Key as part of the request which will be specified in the example_config file. The request without the key will still function as expected. Modified Readme to include the EMAIL_REP_KEY in the config file.

## Does this fix a known existing bug under Issues? ##
This commit fixes Issue -42.

## Type of Change ##
Please delete any options that **do not** apply here:
- [ ] New Feature
- [ ] Requires documentation additions / changes
