### PR TITLE
Add python script header

### DIFF
--- a/Sooty.py
+++ b/Sooty.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
     Title:      Sooty
     Desc:       The SOC Analysts all-in-one CLI tool to automate and speed up workflow.


### PR DESCRIPTION
## Description ##
I've added a short python script header so bash recognizes Sooty.py as an executable file.

## Type of Change ##
Please delete any options that **do not** apply here:
- [ ] New Feature