### PR TITLE
Fix 'AttributeError: module 'tkinter' has no attribute 'filedialog'' …

### DIFF
--- a/Sooty.py
+++ b/Sooty.py
@@ -22,6 +22,7 @@ import urllib.parse
 import requests
 from ipwhois import IPWhois
 import tkinter
+import tkinter.filedialog
 import sys
 
 from Modules import iplists


### PR DESCRIPTION
…fatal error in Option 5(Hashing functions)

## Description ##
Fix the error "AttributeError: module 'tkinter' has no attribute 'filedialog'" we have on some Python installs


## Type of Change ##
Please delete any options that **do not** apply here:
- [ ] Bug Fix

